### PR TITLE
Send funds after stopping extra rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This pallet uses the following hooks:
 | `UpdateOrigin`           | Origin that can dictate updating parameters of this pallet.                                          |
 | `PotId`                  | Account Identifier from which the internal pot is generated.                                         |
 | `ExtraRewardPotId`       | Account Identifier from which the extra reward pot is generated.                                     |
+| `ExtraRewardReceiver`    | Account that will receive all funds in the extra reward pot when those are stopped.                  |
 | `MinEligibleCollators`   | Minimum number eligible collators including Invulnerables.                                           |
 | `MaxInvulnerables`       | Maximum number of invulnerables.                                                                     |
 | `KickThreshold`          | Candidates will be removed from active collator set, if block is not produced within this threshold. |

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -196,6 +196,13 @@ impl<T> sp_runtime::traits::Convert<AccountId, Option<AccountId>> for IdentityCo
 	}
 }
 
+pub struct SendFundsToAccount40;
+impl Get<Option<AccountId>> for SendFundsToAccount40 {
+	fn get() -> Option<AccountId> {
+		Some(40)
+	}
+}
+
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -203,6 +210,7 @@ impl Config for Test {
 	type UpdateOrigin = EnsureSignedBy<RootAccount, u64>;
 	type PotId = PotId;
 	type ExtraRewardPotId = ExtraRewardPotId;
+	type ExtraRewardReceiver = SendFundsToAccount40;
 	type MaxCandidates = ConstU32<20>;
 	type MinEligibleCollators = ConstU32<1>;
 	type MaxInvulnerables = ConstU32<20>;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1958,7 +1958,10 @@ fn set_extra_reward() {
 
 		// Revert the changes
 		assert_ok!(CollatorStaking::stop_extra_reward(RuntimeOrigin::signed(RootAccount::get()),));
-		System::assert_last_event(RuntimeEvent::CollatorStaking(Event::ExtraRewardRemoved {}));
+		System::assert_last_event(RuntimeEvent::CollatorStaking(Event::ExtraRewardRemoved {
+			amount_left: 0,
+			receiver: Some(40),
+		}));
 		assert_eq!(ExtraReward::<Test>::get(), 0);
 	});
 }
@@ -2327,7 +2330,10 @@ fn stop_extra_reward() {
 		assert_ok!(CollatorStaking::set_extra_reward(RuntimeOrigin::signed(RootAccount::get()), 2));
 		assert_ok!(CollatorStaking::stop_extra_reward(RuntimeOrigin::signed(RootAccount::get())));
 
-		System::assert_last_event(RuntimeEvent::CollatorStaking(Event::ExtraRewardRemoved {}));
+		System::assert_last_event(RuntimeEvent::CollatorStaking(Event::ExtraRewardRemoved {
+			amount_left: 100,
+			receiver: Some(40),
+		}));
 		assert_eq!(ExtraReward::<Test>::get(), 0);
 	});
 }


### PR DESCRIPTION
This PR adds a trait that allows to define an optional destination account that will receive funds in the extra reward. The destination, if specified, should likely be Treasury or any well-known account.

It also adds a default implementation that keeps the funds in the pot.