### PR TITLE
Post testing improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,8 +538,10 @@ pub mod pallet {
 		TooFewCandidates,
 		/// Rewards from previous sessions have not yet been claimed.
 		PreviousRewardsNotClaimed,
-		/// User has not Staked on the given Candidate
+		/// User has not Staked on the given Candidate.
 		NoStakeOnCandidate,
+		// No rewards to claim as previous claim happened on the same session.
+		NoPendingClaim,
 	}
 
 	#[pallet::hooks]
@@ -1062,6 +1064,10 @@ pub mod pallet {
 		))]
 		pub fn claim_rewards(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
+
+			//Staker can't claim in the same session as there are no rewards
+			ensure!(!Self::staker_has_claimed(&who), Error::<T>::NoPendingClaim);
+
 			let (candidates, rewards) = Self::do_claim_rewards(&who)?;
 			Ok(Some(T::WeightInfo::claim_rewards(candidates, rewards)).into())
 		}


### PR DESCRIPTION
After thoroughly testing the pallet improvements where added
- should_claim() runtimeApi allows to query whether the `claim_rewards()` extrinsic should be called before running other extrinsics that require claiming.
- If no rewards are available an error is returned on `claim_rewards()`