### PR TITLE
Fix restake bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3197,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -3368,7 +3368,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "Inflector",
  "expander",
@@ -3433,7 +3433,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 
 [[package]]
 name = "sp-storage"
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -3558,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#e051f3edd3d6a0699a9261c8f8985d2e8e95c276"
+source = "git+https://github.com/paritytech/polkadot-sdk#698d9ae5b32785d3a5a55b770e973bbdb59ad271"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",

--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -597,7 +597,7 @@ mod benchmarks {
 		}
 	}
 
-	//Worst case is if stake exists
+	// Worst case is if stake exists
 	#[benchmark]
 	fn set_autocompound_percentage() {
 		let caller = prepare_staker::<T>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,7 +755,9 @@ pub mod pallet {
 		///
 		/// This call is not available to `Invulnerable` collators.
 		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::register_as_candidate())]
+		#[pallet::weight(
+			T::WeightInfo::register_as_candidate() + T::WeightInfo::remove_worst_candidate()
+		)]
 		pub fn register_as_candidate(
 			origin: OriginFor<T>,
 			bond: BalanceOf<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,7 +543,7 @@ pub mod pallet {
 		/// The extra reward pot account was funded.
 		ExtraRewardPotFunded { pot: T::AccountId, amount: BalanceOf<T> },
 		/// The staking locked amount got extended.
-		LockExtended { amount: BalanceOf<T> },
+		LockExtended { account: T::AccountId, amount: BalanceOf<T> },
 		/// A candidate's candidacy bond got updated.
 		CandidacyBondUpdated { candidate: T::AccountId, new_bond: BalanceOf<T> },
 	}
@@ -1919,7 +1919,7 @@ pub mod pallet {
 			let total = Self::get_staked_balance(account).saturating_add(amount);
 			T::Currency::set_freeze(&FreezeReason::Staking.into(), account, total)?;
 
-			Self::deposit_event(Event::<T>::LockExtended { amount });
+			Self::deposit_event(Event::<T>::LockExtended { account: account.clone(), amount });
 			Ok(())
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1574,6 +1574,8 @@ pub mod pallet {
 		pub fn staker_has_claimed(who: &T::AccountId) -> bool {
 			UserStake::<T>::get(who)
 				.maybe_last_reward_session
+				// Theoretically you cannot receive rewards in the future, but regardless, it
+				// should yield the same result.
 				.map(|last_reward_session| last_reward_session >= CurrentSession::<T>::get())
 				.unwrap_or(true)
 		}
@@ -1705,6 +1707,8 @@ pub mod pallet {
 					.map_err(|_| Error::<T>::TooManyReleaseRequests)?;
 				Ok(())
 			})?;
+			// Since the process of unstaking leads to penalties, this lets users stake new funds
+			// without penalties on them, while still tracking their previously unstaked funds.
 			// If the user just unstaked and unlocked the funds we can decrease the unavailable amount
 			// to stake. This is to allow users that decided to lock more funds during the penalty
 			// period not to have a penalty for funds that are no longer available to be staked, since

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -36,6 +36,7 @@ use super::*;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = <Test as frame_system::Config>::AccountId;
+type Balance = u64;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
@@ -88,7 +89,7 @@ impl pallet_balances::Config for Test {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = ();
 	type WeightInfo = ();
-	type Balance = u64;
+	type Balance = Balance;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;


### PR DESCRIPTION
This PR:

- Solves two bugs that did not account well for the current funds staked, which affected incoming stake.
- Enhances documentation.
- Increases test coverage by adding several new tests and adding more checks to existing ones.

## Reported Bug Feedback

> 1. Restake logic abuse
To exploit the restake logic, one needs to stake to two collators. Let’s imagine a user has 30 MYTH and stakes 20 MYTH to collator A and 10 MYTH to collator B. At any time, the user can unstake all tokens from collator B (10 MYTH) and restake them to the most performant collator C, effectively bypassing the restake logic check. This is because the condition of the check still holds:
>
> frozen balance (30 MYTH) - unavailable amount (10 MYTH) >= amount to stake to collator C (10 MYTH)
>
> 2. UX issue when staking more after unstaking all tokens
There is an annoying UX issue when a user wants to stake more tokens after unstaking all previously staked tokens.
Let’s say a user has 10 MYTH staked to collator A. At some point, he decides to unstake all tokens, moving 10 MYTH from “Staking freeze” to “Releasing freeze.” Now, the user wants to stake 10 MYTH again by calling lock(10) and then stake(10). However, the stake(10) call fails because the check does not hold, as the frozen balance in the logic only accounts for the “Staking freeze”:
>
>frozen balance (10 MYTH)} - unavailable amount (10 MYTH) >= amount to stake to collator B (10 MYTH)