### PR TITLE
Count already claimed rewards per session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-staking"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://blockdeep.io"
 license = "Apache-2.0"
 repository = "https://github.com/blockdeep/pallet-collator-staking"
-version = "1.2.0"
+version = "1.2.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,8 +1273,8 @@ pub mod pallet {
 				let mut total_candidates = 0;
 				if let Some(last_reward_session) = user_stake_info.maybe_last_reward_session {
 					let current_session = CurrentSession::<T>::get();
-					// If the user took a really long time since he last collected the rewards we
-					// can skip rewards we already know they have been discarded.
+					// If the user has not collected rewards from sessions past the `MaxRewardSessions`
+					// limit we can skip rewards we already know they have been discarded.
 					let last_reward_session = last_reward_session
 						.max(current_session.saturating_sub(T::MaxRewardSessions::get()));
 					let mut candidate_rewards = user_stake_info


### PR DESCRIPTION
This PR brings the following changes:

- Optimizes pending reward calculation: now, if the user did not claim rewards for a long period of time and their rewards were already discarded, the system will start processing rewards from the first one that has not yet been removed, saving a lot of potential storage reads.
- Reintroduces session rewards with zero value. This is so that there can be predictability on which rewards the system already keeps track of.
- Fixes an error by which when a session was removed the whole amount for that session was released back to the pot, while partial rewards for different stakers might have been collected through time and should not have been reintroduced in the pot. For that it adds the `claimed_rewards` variable in `SessionInfo`.