### PR TITLE
Fix: accumulate already claimed session rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-staking"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://blockdeep.io"
 license = "Apache-2.0"
 repository = "https://github.com/blockdeep/pallet-collator-staking"
-version = "1.2.3"
+version = "1.2.4"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1303,8 +1303,8 @@ pub mod pallet {
 								total_rewards.saturating_accrue(session_total_reward);
 								total_unclaimable_rewards
 									.saturating_accrue(session_unclaimable_rewards);
-								session_rewards.claimed_rewards =
-									session_total_reward.saturating_add(total_unclaimable_rewards);
+								session_rewards.claimed_rewards.saturating_accrue(
+									session_total_reward.saturating_add(total_unclaimable_rewards));
 							}
 						});
 					}


### PR DESCRIPTION
This PR fixes an error introduced in #29 that did not accumulate properly already claimed rewards for a given session.