### PR TITLE
Add new extrinsic to permissionlessly claim rewards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1198,14 +1198,14 @@ pub mod pallet {
 			Ok(Some(T::WeightInfo::claim_rewards(candidates, rewards)).into())
 		}
 
-		/// Claims all pending rewards for `other`.
+		/// Claims all pending rewards for `target`.
 		///
 		/// Distributes rewards accumulated over previous sessions
 		/// and ensures that rewards are only claimable for sessions where the
-		/// `other` has participated. Rewards for the current session cannot be claimed.
+		/// `target` has participated. Rewards for the current session cannot be claimed.
 		///
 		/// **Errors**:
-		/// - `Error::<T>::NoPendingClaim`: `other` has no rewards to claim.
+		/// - `Error::<T>::NoPendingClaim`: `target` has no rewards to claim.
 		#[pallet::call_index(21)]
 		#[pallet::weight(T::WeightInfo::claim_rewards(
 			T::MaxStakedCandidates::get(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1213,15 +1213,15 @@ pub mod pallet {
 		))]
 		pub fn claim_rewards_other(
 			origin: OriginFor<T>,
-			other: T::AccountId,
+			target: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			// We do not care about the sender.
 			ensure_signed(origin)?;
 
 			// Staker can't claim in the same session as there are no rewards.
-			ensure!(!Self::staker_has_claimed(&other), Error::<T>::NoPendingClaim);
+			ensure!(!Self::staker_has_claimed(&target), Error::<T>::NoPendingClaim);
 
-			let (candidates, rewards) = Self::do_claim_rewards(&other)?;
+			let (candidates, rewards) = Self::do_claim_rewards(&target)?;
 			Ok(Some(T::WeightInfo::claim_rewards(candidates, rewards)).into())
 		}
 	}


### PR DESCRIPTION
This PR adds an extra extrinsic to permissionlessly claim rewards. This allows any account with funds to claim the rewards on behalf of someone else.